### PR TITLE
Allow pytorch 1.13.1

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
-      - run: pip install -e ".[dev]"
+      - run: pip install ".[dev]"
       - name: Run pre-commit checks
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install PyTorch
         run: pip install ${{ matrix.torch-version }}
       - name: Install package
-        run: pip install -e ".[dev]"
+        run: pip install ".[dev]"
       - name: Run tests (excluding slow tests)
         run: pytest -k "not slow"
 
@@ -42,6 +42,6 @@ jobs:
           cache: "pip"
       - name: Install PyTorch
         run: pip install ${{ matrix.torch-version }}
-      - run: pip install -e ".[dev]"
+      - run: pip install ".[dev]"
       - name: Run all tests
         run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        torch-version: ["1.13.1", ">=2.0"]
+        torch-version: ["torch==1.13.1", "torch>=2.0"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -21,7 +21,7 @@ jobs:
           python-version: "3.11"
           cache: "pip"
       - name: Install PyTorch
-        run: pip install torch==${{ matrix.torch-version }}
+        run: pip install ${{ matrix.torch-version }}
       - name: Install package
         run: pip install -e ".[dev]"
       - name: Run tests (excluding slow tests)
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        torch-version: ["1.13.1", ">=2.0"]
+        torch-version: ["torch==1.13.1", "torch>=2.0"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -41,7 +41,7 @@ jobs:
           python-version: "3.11"
           cache: "pip"
       - name: Install PyTorch
-        run: pip install torch==${{ matrix.torch-version }}
+        run: pip install ${{ matrix.torch-version }}
       - run: pip install -e ".[dev]"
       - name: Run all tests
         run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,8 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
-      - name: Install PyTorch
-        run: pip install ${{ matrix.torch-version }}
-      - name: Install package
-        run: pip install ".[dev]"
+      - name: Install package and dependencies
+        run: pip install ".[dev]" ${{ matrix.torch-version }}
       - name: Run tests (excluding slow tests)
         run: pytest -k "not slow"
 
@@ -40,8 +38,7 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
-      - name: Install PyTorch
-        run: pip install ${{ matrix.torch-version }}
-      - run: pip install ".[dev]"
+      - name: Install package and dependencies
+        run: pip install ".[dev]" ${{ matrix.torch-version }}
       - name: Run all tests
         run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
   test-on-push:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        torch-version: ["1.13.1", ">=2.0"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -17,13 +20,19 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
-      - run: pip install -e ".[dev]"
+      - name: Install PyTorch
+        run: pip install torch==${{ matrix.torch-version }}
+      - name: Install package
+        run: pip install -e ".[dev]"
       - name: Run tests (excluding slow tests)
         run: pytest -k "not slow"
 
   test-on-pull-request:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        torch-version: ["1.13.1", ">=2.0"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -31,6 +40,8 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
+      - name: Install PyTorch
+        run: pip install torch==${{ matrix.torch-version }}
       - run: pip install -e ".[dev]"
       - name: Run all tests
         run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "dataset_baselines"
-version = "0.2.1"
+version = "0.2.2"
 description = "Benchmark datasets and experiments"
 licence = "MIT"
 authors = [
@@ -15,7 +15,7 @@ packages = [{ include = "dataset_baselines", from = "." }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-torch = "^2.0"                                  # Installs cuda version if available
+torch = "^1.13 || >=2.0"                        # Installs cuda version if available
 torch-geometric = "^2.0"
 lightning = "^2.0"
 scipy = "*"

--- a/tests/datasets/test_skafte.py
+++ b/tests/datasets/test_skafte.py
@@ -13,7 +13,7 @@ class TestSkafteDataset:
         dataset = SkafteDataset(num_samples=num_samples, heteroscedastic=heteroscedastic, x_bounds=x_bounds, seed=seed)
         assert len(dataset) == num_samples
         x, y = dataset[0]
-        assert x.shape == y.shape == torch.Size([])
+        assert x.shape == y.shape == torch.Size([1])
 
         # Assert all x values are within bounds
         assert (x >= x_bounds[0]).all()


### PR DESCRIPTION
There are still a lot of packages that do not yet support 2.0 and above.
The pacakge will specifically allow using 1.13.1, and test this version in CI.